### PR TITLE
feat: add localhost HTTP API for external tool integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,72 @@ Configure where your data is stored:
 
 ---
 
+## External API (Local HTTP)
+
+While the extension is active, it exposes a localhost-only HTTP API so external tools (Claude Code skills, GitHub Copilot, custom scripts) can drive its commands instead of editing `.chroma/chroma.db` directly. Routing mutations through the running extension keeps VS Code's in-memory state authoritative and prevents the silent overwrites that happen when an external writer races with the extension's `saveDatabase()` calls.
+
+### Discovery
+
+On activation the extension writes `<workspace>/.chroma/api.json`:
+
+```json
+{
+  "port": 51873,
+  "token": "<64-char hex>",
+  "pid": 12345,
+  "version": "2.23.0",
+  "startedAt": "2026-06-25T18:00:00.000Z"
+}
+```
+
+The file is rewritten on every activation (token rotates per VS Code session) and deleted on deactivate. `.chroma/` is gitignored, so the token never leaves the machine.
+
+### Endpoints
+
+- `GET /health` — `{ ok, version, pid }`. No auth. Use as a liveness probe.
+- `GET /commands` — discovery list of exposed commands and their parameter schemas. Requires `Authorization: Bearer <token>`.
+- `POST /commands/:commandId` — JSON body of arguments. Requires bearer auth. The server invokes `vscode.commands.executeCommand(commandId, { __api: true, ...body })` and returns `{ ok, data }` on success or `{ ok: false, error }` on failure.
+
+### Security
+
+- Bound to `127.0.0.1` only. Requests whose `Host` header is not `127.0.0.1` or `localhost` get 403.
+- Bearer token required on everything except `/health`. Compared with `crypto.timingSafeEqual`.
+- Only `GET` and `POST` accepted; other methods get 405.
+- Request body capped at 1 MB.
+- No CORS headers (browser callers are blocked intentionally).
+
+### Phase 1 exposed commands
+
+| Command | Required params | Optional params |
+|---|---|---|
+| `chroma.addBoard` | `title` | |
+| `chroma.addCard` | `columnId`, `title` | `content`, `position`, `tagIds[]` |
+| `chroma.editCard` | `cardId` | `title`, `content`, `tagIds[]` |
+| `chroma.moveCard` | `cardId`, `columnId` | `position` |
+| `chroma.deleteCard` | `cardId` | |
+| `chroma.addTask` | `title`, `dueDate` | `description`, `recurrence`, `boardId`, `tagIds[]` |
+| `chroma.completeTask` | `taskId` | |
+| `chroma.deleteTask` | `taskId` | |
+
+### Example
+
+```bash
+PORT=$(jq -r .port .chroma/api.json)
+TOKEN=$(jq -r .token .chroma/api.json)
+
+curl -s http://127.0.0.1:$PORT/health
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:$PORT/commands
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Created via API"}' \
+  http://127.0.0.1:$PORT/commands/chroma.addBoard
+```
+
+When the extension is not running, `.chroma/api.json` will be absent — external tools should fall back to reading/writing the SQLite file directly.
+
+---
+
 ##  Debugging & Troubleshooting
 
 ### Debug Logging

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -600,7 +600,10 @@ export async function completeTask(arg?: any) {
     // API path
     if (arg && arg.__api === true) {
         const taskId = arg.taskId;
-        prepare('UPDATE tasks SET status = ? WHERE id = ?').run('completed', taskId);
+        const info = prepare('UPDATE tasks SET status = ? WHERE id = ?').run('completed', taskId);
+        if (info.changes === 0) {
+            throw new Error(`task not found: ${taskId}`);
+        }
         saveDatabase();
         return { completed: true, id: taskId };
     }
@@ -626,7 +629,10 @@ export async function deleteTask(arg?: any) {
     // API path
     if (arg && arg.__api === true) {
         const taskId = arg.taskId;
-        prepare('DELETE FROM tasks WHERE id = ?').run(taskId);
+        const info = prepare('DELETE FROM tasks WHERE id = ?').run(taskId);
+        if (info.changes === 0) {
+            throw new Error(`task not found: ${taskId}`);
+        }
         saveDatabase();
         return { deleted: true, id: taskId };
     }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getDb, prepare, addTagToTask, removeTagFromTask, getTagsByTaskId, getTagsByCardId, getAllBoards, saveDatabase, createCard, getColumnsByBoardId, createBoard, createColumn, addTagToCard, copyTaskTagsToCard, reorderCardsOnInsert, reorderCardsOnRemove, getColumnById, getCardById, deleteCard } from './database';
+import { prepare, addTagToTask, removeTagFromTask, getTagsByTaskId, getTagsByCardId, getAllBoards, saveDatabase, createCard, getColumnsByBoardId, createBoard, createColumn, addTagToCard, copyTaskTagsToCard, reorderCardsOnInsert, reorderCardsOnRemove, getColumnById, getCardById, deleteCard } from './database';
 import { v4 as uuidv4 } from 'uuid';
 import { selectOrCreateTags } from '../vscode/Tag';
 import { getSettingsService } from './logic/SettingsService';
@@ -243,7 +243,6 @@ export async function convertCardToTask(card: Card) {
     }
 
     try {
-        const db = getDb();
         const id = uuidv4();
         prepare('INSERT INTO tasks (id, title, description, due_date, recurrence, card_id, board_id) VALUES (?, ?, ?, ?, ?, ?, ?)')
             .run(id, title, description, dueDate, recurrence.value, cardId, boardId);
@@ -391,7 +390,6 @@ export async function addTask(arg?: any) {
     // If no boards exist, boardId remains null
 
     try {
-        const db = getDb();
         const id = uuidv4();
         prepare('INSERT INTO tasks (id, title, description, due_date, recurrence, board_id) VALUES (?, ?, ?, ?, ?, ?)')
             .run(id, title, description || null, dueDate, recurrence.value, boardId);
@@ -475,7 +473,6 @@ export async function editTask(task: Task) {
     // If no boards exist, boardId remains null or task's existing value
 
     try {
-        const db = getDb();
         prepare('UPDATE tasks SET title = ?, description = ?, due_date = ?, recurrence = ?, board_id = ? WHERE id = ?')
           .run(title, description !== undefined ? description : task.description || null, dueDate, recurrence.value, boardId, task.id);
         // Integrated tag editing flow
@@ -616,7 +613,6 @@ export async function completeTask(arg?: any) {
     }
 
     try {
-        const db = getDb();
         prepare('UPDATE tasks SET status = ? WHERE id = ?').run('completed', task.id);
         saveDatabase();
         vscode.window.showInformationMessage('Task completed.');
@@ -645,7 +641,6 @@ export async function deleteTask(arg?: any) {
     }
 
     try {
-        const db = getDb();
         prepare('DELETE FROM tasks WHERE id = ?').run(task.id);
         saveDatabase();
         vscode.window.showInformationMessage('Task deleted.');

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -303,7 +303,44 @@ export async function convertCardToTask(card: Card) {
     }
 }
 
-export async function addTask() {
+export async function addTask(arg?: any) {
+    // API path
+    if (arg && arg.__api === true) {
+        const title = arg.title;
+        const description = arg.description !== undefined ? arg.description : null;
+        const dueDate = arg.dueDate;
+        const recurrence = arg.recurrence !== undefined ? arg.recurrence : null;
+
+        let boardId: string | null = null;
+        if (arg.boardId !== undefined) {
+            boardId = arg.boardId;
+        } else {
+            const boards = getAllBoards();
+            if (boards.length === 1) {
+                boardId = boards[0].id;
+            }
+            // If 0 or multiple boards, default to null
+        }
+
+        const id = uuidv4();
+        prepare('INSERT INTO tasks (id, title, description, due_date, recurrence, board_id) VALUES (?, ?, ?, ?, ?, ?)')
+            .run(id, title, description, dueDate, recurrence, boardId);
+
+        if (arg.tagIds && arg.tagIds.length > 0) {
+            for (const tagId of arg.tagIds) {
+                try {
+                    addTagToTask(id, tagId);
+                } catch (err: any) {
+                    console.error(`Failed to add tag ${tagId} to task ${id}:`, err);
+                }
+            }
+        }
+
+        saveDatabase();
+        return { id, title, description, dueDate, recurrence, boardId };
+    }
+
+    // Non-API path (original behavior)
     const title = await vscode.window.showInputBox({
         prompt: 'Enter task title',
     });
@@ -330,22 +367,22 @@ export async function addTask() {
     // Check if there are multiple boards and prompt for board selection
     let boardId: string | null = null;
     const boards = getAllBoards();
-    
+
     if (boards.length > 1) {
         const boardItems = boards.map(board => ({
             label: board.title,
             description: board.id,
             boardId: board.id
         }));
-        
+
         const selectedBoard = await vscode.window.showQuickPick(boardItems, {
             placeHolder: 'Select which board this task should be sent to'
         });
-        
+
         if (!selectedBoard) {
             return; // User cancelled board selection
         }
-        
+
         boardId = selectedBoard.boardId;
     } else if (boards.length === 1) {
         // Only one board exists, use it automatically
@@ -358,7 +395,7 @@ export async function addTask() {
         const id = uuidv4();
         prepare('INSERT INTO tasks (id, title, description, due_date, recurrence, board_id) VALUES (?, ?, ?, ?, ?, ?)')
             .run(id, title, description || null, dueDate, recurrence.value, boardId);
-        
+
         // Prompt for tags
         const tagIds = await selectOrCreateTags();
         if (tagIds && tagIds.length > 0) {
@@ -370,7 +407,7 @@ export async function addTask() {
                 }
             }
         }
-        
+
         vscode.window.showInformationMessage('Task added.');
         saveDatabase();
     } catch (err: any) {
@@ -559,7 +596,17 @@ export async function createCardFromTask(task: Task, isManualConversion: boolean
     }
 }
 
-export async function completeTask(task: Task) {
+export async function completeTask(arg?: any) {
+    // API path
+    if (arg && arg.__api === true) {
+        const taskId = arg.taskId;
+        prepare('UPDATE tasks SET status = ? WHERE id = ?').run('completed', taskId);
+        saveDatabase();
+        return { completed: true, id: taskId };
+    }
+
+    // Non-API path (original behavior)
+    const task = arg;
     if (!task) {
         vscode.window.showErrorMessage('No task selected.');
         return;
@@ -575,7 +622,17 @@ export async function completeTask(task: Task) {
     }
 }
 
-export async function deleteTask(task: Task) {
+export async function deleteTask(arg?: any) {
+    // API path
+    if (arg && arg.__api === true) {
+        const taskId = arg.taskId;
+        prepare('DELETE FROM tasks WHERE id = ?').run(taskId);
+        saveDatabase();
+        return { deleted: true, id: taskId };
+    }
+
+    // Non-API path (original behavior)
+    const task = arg;
     if (!task) {
         vscode.window.showErrorMessage('No task selected.');
         return;

--- a/test/apiServer.test.ts
+++ b/test/apiServer.test.ts
@@ -1,0 +1,237 @@
+// Jest tests for the HTTP API router (makeRouter) in vscode/server/apiServer.js.
+//
+// IMPORTANT: jest.config.js has an unanchored moduleNameMapper pattern "vscode"
+// that intercepts any require path containing "vscode", including
+// require('../vscode/server/apiServer'). We bypass this by loading the file
+// directly via Node's vm module, injecting the Jest vscode mock as the only
+// special dependency so assertions on vscode.commands.executeCommand still work.
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const { createRequire } = require('module');
+
+// Load the Jest vscode mock first so we hold a shared reference.
+const vscode = require('vscode');
+
+// ── load apiServer bypassing moduleNameMapper ─────────────────────────────────
+
+const _apiServerPath = path.resolve(__dirname, '../vscode/server/apiServer.js');
+const _apiServerCode: string = fs.readFileSync(_apiServerPath, 'utf8');
+const _nativeReq = createRequire(_apiServerPath);
+
+function _customRequire(name: string): any {
+  if (name === 'vscode') return vscode;   // inject the shared Jest mock
+  return _nativeReq(name);                // built-ins + relative deps via native Node
+}
+(_customRequire as any).resolve = _nativeReq.resolve.bind(_nativeReq);
+(_customRequire as any).cache = _nativeReq.cache;
+(_customRequire as any).extensions = (_nativeReq as any).extensions;
+(_customRequire as any).main = (_nativeReq as any).main;
+
+const _apiServerMod: any = { exports: {} };
+const _fn = vm.runInThisContext(
+  `(function(require,module,exports,__dirname,__filename){\n${_apiServerCode}\n})`,
+  { filename: _apiServerPath },
+);
+_fn(_customRequire, _apiServerMod, _apiServerMod.exports,
+    path.dirname(_apiServerPath), _apiServerPath);
+
+const { makeRouter, generateToken } = _apiServerMod.exports;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function mockReq(opts: { method: string; url: string; host?: string; auth?: string; body?: string }) {
+  const handlers: Record<string, Function[]> = { data: [], end: [], error: [] };
+  const req: any = {
+    url: opts.url,
+    method: opts.method,
+    headers: { host: opts.host ?? '127.0.0.1' },
+    on(event: string, cb: Function) { handlers[event].push(cb); return req; },
+    destroy() {},
+  };
+  if (opts.auth) req.headers.authorization = `Bearer ${opts.auth}`;
+  // Fire body events asynchronously so handlers can be attached first.
+  setImmediate(() => {
+    if (opts.body) handlers.data.forEach((cb) => cb(Buffer.from(opts.body!)));
+    handlers.end.forEach((cb) => cb());
+  });
+  return req;
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: '',
+    writeHead(status: number, headers: any) { res.statusCode = status; Object.assign(res.headers, headers); },
+    setHeader(name: string, value: any) { res.headers[name] = value; },
+    end(body: string) { res.body = body; res._done?.(); },
+  };
+  res.done = new Promise<void>((resolve) => { res._done = resolve; });
+  return res;
+}
+
+// ── test setup ────────────────────────────────────────────────────────────────
+
+const TOKEN = 'test-token-1234567890';
+const router = makeRouter({ token: TOKEN, version: '9.9.9', debugLog: () => {} });
+
+beforeEach(() => {
+  (vscode.commands.executeCommand as jest.Mock).mockReset();
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /health', () => {
+  it('returns 200 with ok, version, pid — no auth required', async () => {
+    const req = mockReq({ method: 'GET', url: '/health' });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.version).toBe('9.9.9');
+    expect(typeof body.pid).toBe('number');
+  });
+});
+
+describe('GET /commands — auth checks', () => {
+  it('returns 401 when no Authorization header is provided', async () => {
+    const req = mockReq({ method: 'GET', url: '/commands' });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).ok).toBe(false);
+  });
+
+  it('returns 401 with wrong Bearer token', async () => {
+    const req = mockReq({ method: 'GET', url: '/commands', auth: 'wrong-token' });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 200 with valid token — data is non-empty array containing chroma.addBoard', async () => {
+    const req = mockReq({ method: 'GET', url: '/commands', auth: TOKEN });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+    expect(body.data.some((c: any) => c.id === 'chroma.addBoard')).toBe(true);
+  });
+});
+
+describe('POST /commands/chroma.addBoard', () => {
+  it('returns 200 and calls executeCommand with merged __api flag', async () => {
+    (vscode.commands.executeCommand as jest.Mock).mockResolvedValue({ id: 'b1', title: 'Test Board' });
+    const req = mockReq({
+      method: 'POST',
+      url: '/commands/chroma.addBoard',
+      auth: TOKEN,
+      body: JSON.stringify({ title: 'Test Board' }),
+    });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(200);
+    expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'chroma.addBoard',
+      { __api: true, title: 'Test Board' },
+    );
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({ id: 'b1', title: 'Test Board' });
+  });
+
+  it('returns 400 with details array when required param title is missing', async () => {
+    const req = mockReq({
+      method: 'POST',
+      url: '/commands/chroma.addBoard',
+      auth: TOKEN,
+      body: JSON.stringify({}),
+    });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(Array.isArray(body.details)).toBe(true);
+    expect(body.details.some((d: string) => d.includes('title'))).toBe(true);
+  });
+});
+
+describe('POST /commands/chroma.unknown', () => {
+  it('returns 404 for an unregistered command id', async () => {
+    const req = mockReq({
+      method: 'POST',
+      url: '/commands/chroma.unknown',
+      auth: TOKEN,
+      body: '{}',
+    });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).ok).toBe(false);
+  });
+});
+
+describe('Method not allowed', () => {
+  it('returns 405 with Allow header for PUT requests', async () => {
+    const req = mockReq({ method: 'PUT', url: '/commands/chroma.addBoard', auth: TOKEN });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(405);
+    expect(res.headers['Allow']).toBe('GET, POST');
+  });
+});
+
+describe('Host header check', () => {
+  it('returns 403 for requests from a non-localhost host', async () => {
+    const req = mockReq({ method: 'GET', url: '/health', host: 'evil.com' });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).ok).toBe(false);
+  });
+});
+
+describe('executeCommand error handling', () => {
+  it('returns 500 with ok:false and the error message when executeCommand rejects', async () => {
+    (vscode.commands.executeCommand as jest.Mock).mockRejectedValue(new Error('boom'));
+    const req = mockReq({
+      method: 'POST',
+      url: '/commands/chroma.addBoard',
+      auth: TOKEN,
+      body: JSON.stringify({ title: 'Test Board' }),
+    });
+    const res = mockRes();
+    router(req, res);
+    await res.done;
+    expect(res.statusCode).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('boom');
+  });
+});
+
+describe('generateToken', () => {
+  it('returns a 64-character hex string', () => {
+    const token = generateToken();
+    expect(typeof token).toBe('string');
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/test/database-persistence.test.ts
+++ b/test/database-persistence.test.ts
@@ -58,7 +58,7 @@ describe('Database Persistence', () => {
             fs.unlinkSync(testDbPath);
         }
         if (fs.existsSync(testDbDir)) {
-            fs.rmdirSync(testDbDir, { recursive: true });
+            fs.rmSync(testDbDir, { recursive: true, force: true });
         }
     });
 

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -500,6 +500,7 @@ exports.activate = async function activate(context) {
       context.subscriptions.push({ dispose: () => apiServer.stop() });
     } catch (e) {
       getDebugLogger().log('ERROR: Failed to start API server:', e?.message || String(e));
+      vscode.window.showWarningMessage('Chroma: HTTP API failed to start — external tools will not be able to connect.');
     }
   }
 

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -504,9 +504,6 @@ exports.activate = async function activate(context) {
     }
   }
 
-  // Note: Database initialization is already handled earlier in the activate function (lines 68-82)
-  // This duplicate initialization block has been removed to prevent conflicts
-
   vscode.workspace.onDidOpenTextDocument((document) => {
     if (document.languageId === 'notesnlh') {
       try {

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -98,11 +98,15 @@ exports.activate = async function activate(context) {
       getDebugLogger().log('Initializing database with workspace root');
       await initDatabase(false, workspaceRoot);
       getDebugLogger().log('Database initialized successfully');
-      
+
       // Auto-normalize card positions on startup to fix gaps from deletions/bugs
       getDebugLogger().log('Running card position normalization');
       normalizeAllCardPositions();
       getDebugLogger().log('Card position normalization complete');
+    } else {
+      getDebugLogger().log('No workspace folder open — skipping database init and provider registration');
+      vscode.window.showWarningMessage('Chroma: No workspace folder open. Open a folder to use Chroma Workspace.');
+      return;
     }
   } catch (e) {
     getDebugLogger().log('ERROR: Database initialization failed');

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -28,6 +28,7 @@ const { addNote, editNote } = require('./Note');
 const { exportAccomplishments } = require('../out/src/logic/ExportAccomplishments');
 const { importFromJson, exportToJson } = require('../out/src/logic/Migration');
 const { GitService } = require('../out/src/services/gitService');
+const { startApiServer } = require('./server/apiServer');
 
 // Explicit helpers to avoid ambiguous toggle behavior between hide/show commands.
 function hideColumn(column) {
@@ -162,11 +163,11 @@ exports.activate = async function activate(context) {
     vscode.commands.registerCommand('chroma.refreshNotes', () => {
       notesProvider.refresh();
     }),
-    vscode.commands.registerCommand('chroma.addBoard', () => {
-        addBoard().then(() => {
-            kanbanProvider.refresh();
-            DashboardProvider.refresh();
-        });
+    vscode.commands.registerCommand('chroma.addBoard', async (arg) => {
+        const result = await addBoard(arg);
+        kanbanProvider.refresh();
+        DashboardProvider.refresh();
+        return result;
     }),
     vscode.commands.registerCommand('chroma.editBoard', (board) => {
         editBoard(board).then(() => {
@@ -213,29 +214,29 @@ exports.activate = async function activate(context) {
     vscode.commands.registerCommand('chroma.copyBoardId', (board) => {
         copyBoardId(board);
     }),
-    vscode.commands.registerCommand('chroma.addCard', (column) => {
-      addCard(column).then(() => {
+    vscode.commands.registerCommand('chroma.addCard', async (arg) => {
+      const result = await addCard(arg);
+      kanbanProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
+    }),
+    vscode.commands.registerCommand('chroma.editCard', async (arg) => {
+      const result = await editCard(arg);
+      kanbanProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
+    }),
+    vscode.commands.registerCommand('chroma.deleteCard', async (arg) => {
+        const result = await deleteCard(arg);
         kanbanProvider.refresh();
         DashboardProvider.refresh();
-      });
+        return result;
     }),
-    vscode.commands.registerCommand('chroma.editCard', (card) => {
-      editCard(card).then(() => {
-        kanbanProvider.refresh();
-        DashboardProvider.refresh();
-      });
-    }),
-    vscode.commands.registerCommand('chroma.deleteCard', (card) => {
-        deleteCard(card).then(() => {
-            kanbanProvider.refresh();
-            DashboardProvider.refresh();
-        });
-    }),
-    vscode.commands.registerCommand('chroma.moveCard', (card) => {
-      moveCard(card).then(() => {
-        kanbanProvider.refresh();
-        DashboardProvider.refresh();
-      });
+    vscode.commands.registerCommand('chroma.moveCard', async (arg) => {
+      const result = await moveCard(arg);
+      kanbanProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
     }),
     vscode.commands.registerCommand('chroma.editCardCompletedDate', (card) => {
       editCardCompletedDate(card).then(() => {
@@ -250,11 +251,11 @@ exports.activate = async function activate(context) {
         DashboardProvider.refresh();
       });
     }),
-    vscode.commands.registerCommand('chroma.addTask', () => {
-      addTask().then(() => {
-        taskProvider.refresh();
-        DashboardProvider.refresh();
-      });
+    vscode.commands.registerCommand('chroma.addTask', async (arg) => {
+      const result = await addTask(arg);
+      taskProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
     }),
     vscode.commands.registerCommand('chroma.editTask', (task) => {
       editTask(task).then(() => {
@@ -269,17 +270,17 @@ exports.activate = async function activate(context) {
         DashboardProvider.refresh();
       });
     }),
-    vscode.commands.registerCommand('chroma.completeTask', (task) => {
-      completeTask(task).then(() => {
-        taskProvider.refresh();
-        DashboardProvider.refresh();
-      });
+    vscode.commands.registerCommand('chroma.completeTask', async (arg) => {
+      const result = await completeTask(arg);
+      taskProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
     }),
-    vscode.commands.registerCommand('chroma.deleteTask', (task) => {
-      deleteTask(task).then(() => {
-        taskProvider.refresh();
-        DashboardProvider.refresh();
-      });
+    vscode.commands.registerCommand('chroma.deleteTask', async (arg) => {
+      const result = await deleteTask(arg);
+      taskProvider.refresh();
+      DashboardProvider.refresh();
+      return result;
     }),
     vscode.commands.registerCommand('chroma.addTag', () => {
         addTag().then(() => {
@@ -481,6 +482,22 @@ exports.activate = async function activate(context) {
       }
     })
   );
+
+  // Start localhost HTTP API server so external tools (Claude Code, Copilot)
+  // can drive the extension's commands instead of editing chroma.db directly.
+  if (workspaceRoot) {
+    try {
+      const pkgVersion = require('../package.json').version;
+      const apiServer = await startApiServer({
+        workspaceRoot,
+        version: pkgVersion,
+        debugLog: (msg) => getDebugLogger().log(msg),
+      });
+      context.subscriptions.push({ dispose: () => apiServer.stop() });
+    } catch (e) {
+      getDebugLogger().log('ERROR: Failed to start API server:', e?.message || String(e));
+    }
+  }
 
   // Note: Database initialization is already handled earlier in the activate function (lines 68-82)
   // This duplicate initialization block has been removed to prevent conflicts

--- a/vscode/kanban/Board.js
+++ b/vscode/kanban/Board.js
@@ -1,12 +1,18 @@
 const vscode = require('vscode');
 const { createBoard, updateBoard, deleteBoard: dbDeleteBoard, createColumn, updateColumn, deleteColumn: dbDeleteColumn, getColumnById, saveDatabase } = require('../../out/src/database');
 
-async function addBoard() {
-    const boardName = await vscode.window.showInputBox({ prompt: 'Enter a name for the new board' });
-    if (boardName) {
-        createBoard({ title: boardName });
-        saveDatabase();
+async function addBoard(arg) {
+    const isApi = arg && arg.__api === true;
+    let title;
+    if (isApi) {
+        title = arg.title;
+    } else {
+        title = await vscode.window.showInputBox({ prompt: 'Enter a name for the new board' });
     }
+    if (!title) return;
+    const board = createBoard({ title });
+    saveDatabase();
+    return board;
 }
 
 async function editBoard(board) {

--- a/vscode/kanban/Card.js
+++ b/vscode/kanban/Card.js
@@ -1,5 +1,5 @@
 const vscode = require('vscode');
-const { createCard, updateCard, deleteCard: dbDeleteCard, getColumnsByBoardId, addTagToCard, removeTagFromCard, getTagsByCardId, getCardsByColumnId, reorderCardsOnInsert, reorderCardsOnRemove, getCardById, saveDatabase } = require('../../out/src/database');
+const { createCard, updateCard, deleteCard: dbDeleteCard, getColumnsByBoardId, addTagToCard, removeTagFromCard, getTagsByCardId, getCardsByColumnId, reorderCardsOnInsert, reorderCardsOnRemove, getCardById, getColumnById, saveDatabase } = require('../../out/src/database');
 const { selectOrCreateTags } = require('../../out/vscode/Tag');
 const { getDebugLogger } = require('../../out/src/logic/DebugLogger');
 const { getSettingsService } = require('../../out/src/logic/SettingsService');
@@ -98,23 +98,61 @@ async function promptForCardPosition(columnId, columnTitle, excludeCardId, curre
     }
 }
 
-async function addCard(column) {
+async function addCard(arg) {
     const debugLog = getDebugLogger();
+
+    // API path
+    if (arg && arg.__api === true) {
+        const columnId = arg.columnId;
+        const cardTitle = arg.title;
+        const content = arg.content || '';
+
+        const col = getColumnById(columnId);
+        const columnTitle = col ? col.title : '';
+        const completionColumnName = getSettingsService().getKanbanSettings().completionColumn;
+        const isCompletionColumn = columnTitle.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
+
+        let position;
+        if (isCompletionColumn) {
+            position = 1;
+        } else {
+            position = arg.position !== undefined ? arg.position : 1;
+            reorderCardsOnInsert(columnId, position);
+        }
+
+        const newCard = createCard({ title: cardTitle, content, column_id: columnId, position, card_type: 'simple', priority: 0 });
+        if (!newCard || !newCard.id) {
+            throw new Error('Failed to create card - no ID returned');
+        }
+
+        const tagIds = arg.tagIds;
+        if (tagIds && tagIds.length > 0) {
+            for (const tagId of tagIds) {
+                addTagToCard(newCard.id, tagId);
+            }
+        }
+
+        saveDatabase();
+        return newCard;
+    }
+
+    // Non-API path (original behavior)
+    const column = arg;
     const cardTitle = await vscode.window.showInputBox({ prompt: 'Enter a title for the new card' });
     if (!cardTitle) {
         return;
     }
     const content = await vscode.window.showInputBox({ prompt: 'Optional: Enter content/context for this card' });
-    
+
     debugLog.log('=== Creating new card ===');
     debugLog.log('Column ID:', column.columnId);
     debugLog.log('Card title:', cardTitle);
     debugLog.log('Column title:', column.label);
-    
+
     // Determine if this is a completion column
     const completionColumnName = getSettingsService().getKanbanSettings().completionColumn;
     const isCompletionColumn = column.label.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
-    
+
     let position;
     if (isCompletionColumn) {
         // Completion columns: auto-assign to top (position 1)
@@ -124,28 +162,28 @@ async function addCard(column) {
         // Non-completion columns: prompt user for position
         position = await promptForCardPosition(column.columnId, column.label);
         debugLog.log('User selected position:', position);
-        
+
         // Reorder existing cards to make space for the new card
         reorderCardsOnInsert(column.columnId, position);
     }
-    
+
     const newCard = createCard({ title: cardTitle, content: content || '', column_id: column.columnId, position: position, card_type: 'simple', priority: 0 });
     debugLog.log('createCard returned:', newCard);
-    
+
     // Verify card was created and has an ID
     if (!newCard || !newCard.id) {
         debugLog.log('ERROR: No card or ID returned from createCard');
         vscode.window.showErrorMessage('Failed to create card - no ID returned');
         return;
     }
-    
+
     debugLog.log('Card created successfully with ID:', newCard.id);
-    
+
     // Prompt for tags
     const tagIds = await selectOrCreateTags();
     if (tagIds && tagIds.length > 0) {
         debugLog.log('Selected tag IDs:', tagIds);
-        
+
         for (const tagId of tagIds) {
             try {
                 debugLog.log(`Adding tag ${tagId} to card ${newCard.id}`);
@@ -157,15 +195,54 @@ async function addCard(column) {
             }
         }
     }
-    
+
     // Save database after all operations
     saveDatabase();
     debugLog.log('Database saved after card creation');
 }
 
-async function editCard(card) {
+async function editCard(arg) {
     const debugLog = getDebugLogger();
-    
+
+    // API path
+    if (arg && arg.__api === true) {
+        const cardId = arg.cardId;
+        let current;
+        try {
+            current = getCardById(cardId);
+        } catch (e) {
+            throw new Error('Card not found: ' + cardId);
+        }
+        if (!current) {
+            throw new Error('Card not found: ' + cardId);
+        }
+
+        const updateData = { id: cardId };
+        if (arg.title !== undefined) updateData.title = arg.title;
+        if (arg.content !== undefined) updateData.content = arg.content;
+
+        updateCard(updateData);
+
+        if (arg.tagIds !== undefined) {
+            const existingTags = getTagsByCardId(cardId);
+            const existingTagIds = existingTags.map(t => t.id);
+            const toAdd = arg.tagIds.filter(id => !existingTagIds.includes(id));
+            const toRemove = existingTagIds.filter(id => !arg.tagIds.includes(id));
+            for (const tagId of toAdd) {
+                addTagToCard(cardId, tagId);
+            }
+            for (const tagId of toRemove) {
+                removeTagFromCard(cardId, tagId);
+            }
+        }
+
+        saveDatabase();
+        return getCardById(cardId);
+    }
+
+    // Non-API path (original behavior)
+    const card = arg;
+
     // Check if vacation mode applies for this card's board
     const { getColumnById: _getColumnById, getBoardById: _getBoardById } = require('../../out/src/database');
     const boardIdForEdit = card.boardId || _getColumnById(card.columnId)?.board_id;
@@ -188,13 +265,13 @@ async function editCard(card) {
     } catch (e) {
         // Log error and distinguish between different error types
         console.error('Failed to fetch card for editing:', e);
-        
+
         // If card truly doesn't exist, show error and return
         if (e.message && e.message.includes('does not exist')) {
             vscode.window.showErrorMessage(`Card not found: ${card.label}`);
             return;
         }
-        
+
         // For other errors, log but allow user to continue with current card data
         console.warn('Continuing with fallback card data due to fetch error');
         current = undefined;
@@ -208,11 +285,11 @@ async function editCard(card) {
         value: current?.content || '',
         prompt: 'Optional: Edit content/context for this card'
     });
-    
-    const updateData = { 
-        id: card.cardId, 
-        title: newCardTitle, 
-        content: newContent !== undefined ? newContent : current?.content 
+
+    const updateData = {
+        id: card.cardId,
+        title: newCardTitle,
+        content: newContent !== undefined ? newContent : current?.content
     };
 
     // Check if this is a completion column
@@ -220,24 +297,24 @@ async function editCard(card) {
     const currentColumn = getColumnById(card.columnId);
     const completionColumnName = getSettingsService().getKanbanSettings().completionColumn;
     const isCompletionColumn = currentColumn.title.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
-    
+
     debugLog.log('=== Editing card position ===');
     debugLog.log(`Current position: ${current?.position}`);
     debugLog.log(`Is completion column: ${isCompletionColumn}`);
-    
+
     // Only allow position editing in non-completion columns
     if (!isCompletionColumn) {
         debugLog.log('Prompting user for new position...');
         const currentPos = current?.position || card.position;
         const newPosition = await promptForCardPosition(card.columnId, currentColumn.title, card.cardId, currentPos);
         debugLog.log(`User selected new position: ${newPosition}`);
-        
+
         const currentPosition = current?.position || card.position;
-        
+
         // Only reorder if position actually changed
         if (newPosition !== currentPosition) {
             debugLog.log(`Position changed from ${currentPosition} to ${newPosition}`);
-            
+
             if (newPosition < currentPosition) {
                 // Moving up: decrement cards between new and old position
                 debugLog.log(`Moving up: decrementing cards from position ${newPosition} to ${currentPosition - 1}`);
@@ -259,14 +336,14 @@ async function editCard(card) {
                     updateCard({ id: c.id, position: c.position - 1 });
                 }
             }
-            
+
             updateData.position = newPosition;
             debugLog.log(`Updated card position to ${newPosition}`);
         }
     } else {
         debugLog.log('Skipping position edit for completion column');
     }
-    
+
     updateCard(updateData);
 
     // Tag editing flow integrated into edit
@@ -309,44 +386,120 @@ async function editCard(card) {
     } catch (e) {
         console.error('Failed during tag edit flow:', e);
     }
-    
+
     // Save database after all operations
     saveDatabase();
     debugLog.log('Database saved after card edit');
 }
 
-async function deleteCard(card) {
+async function deleteCard(arg) {
     const debugLog = getDebugLogger();
+
+    // API path
+    if (arg && arg.__api === true) {
+        const cardId = arg.cardId;
+        const currentCard = getCardById(cardId);
+        if (!currentCard) {
+            throw new Error('Card not found: ' + cardId);
+        }
+        const columnId = currentCard.column_id;
+        const position = currentCard.position;
+        dbDeleteCard(cardId);
+        reorderCardsOnRemove(columnId, position);
+        saveDatabase();
+        return { deleted: true, id: cardId };
+    }
+
+    // Non-API path (original behavior)
+    const card = arg;
     const confirm = await vscode.window.showWarningMessage(`Are you sure you want to delete the card "${card.label}"?`, { modal: true }, 'Delete');
     if (confirm === 'Delete') {
         debugLog.log('Deleting card:', card.cardId);
-        
+
         // Get the card's current position and column before deletion
         const currentCard = getCardById(card.cardId);
         const columnId = currentCard.column_id;
         const position = currentCard.position;
-        
+
         debugLog.log(`Card position: ${position}, column: ${columnId}`);
-        
+
         // Delete the card
         dbDeleteCard(card.cardId);
-        
+
         // Reorder remaining cards in the column
         reorderCardsOnRemove(columnId, position);
         debugLog.log(`Reordered cards in column ${columnId} after deletion`);
-        
+
         saveDatabase();
         debugLog.log('Database saved after card deletion');
     }
 }
 
-async function moveCard(card) {
+async function moveCard(arg) {
     const debugLog = getDebugLogger();
     debugLog.log('\n==================== MOVE CARD START ====================');
+
+    // API path
+    if (arg && arg.__api === true) {
+        const cardId = arg.cardId;
+        const destColumnId = arg.columnId;
+
+        const currentCard = getCardById(cardId);
+        if (!currentCard) {
+            throw new Error('Card not found: ' + cardId);
+        }
+
+        const currentColumn = getColumnById(currentCard.column_id);
+        const destColumn = getColumnById(destColumnId);
+        if (!destColumn) {
+            throw new Error('Column not found: ' + destColumnId);
+        }
+
+        const completionColumnName = getSettingsService().getKanbanSettings().completionColumn;
+        const movingToCompletion = destColumn.title.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
+        const movingFromCompletion = currentColumn ? currentColumn.title.toLowerCase().trim() === completionColumnName.toLowerCase().trim() : false;
+
+        // STEP 1: Decrement positions in source column
+        const currentPosition = currentCard.position;
+        reorderCardsOnRemove(currentCard.column_id, currentPosition);
+
+        const updateData = { id: cardId, column_id: destColumnId };
+
+        // STEP 2: Determine position in destination column
+        let position;
+        if (movingToCompletion) {
+            position = 1;
+            updateData.completed_at = new Date().toISOString();
+        } else {
+            if (arg.position !== undefined) {
+                position = arg.position;
+            } else {
+                // Default to bottom of destination column
+                position = getCardsByColumnId(destColumnId).length + 1;
+            }
+            if (movingFromCompletion) {
+                updateData.completed_at = null;
+            }
+        }
+
+        // STEP 3: Reorder existing cards in destination column to make space
+        reorderCardsOnInsert(destColumnId, position);
+
+        updateData.position = position;
+
+        // STEP 4: Update card
+        updateCard(updateData);
+
+        saveDatabase();
+        return getCardById(cardId);
+    }
+
+    // Non-API path (original behavior)
+    const card = arg;
     debugLog.log(`Moving card: "${card.label}"`);
     debugLog.log(`Current position: ${card.position}`);
     debugLog.log(`Current column ID: ${card.columnId}`);
-    
+
     // Check if vacation mode applies for this card's board
     const { getBoardById: _getBoardById } = require('../../out/src/database');
     const boardTitleForMove = card.boardId ? _getBoardById?.(card.boardId)?.title : undefined;
@@ -365,7 +518,7 @@ async function moveCard(card) {
     const columns = getColumnsByBoardId(card.boardId, true); // Include hidden columns so they can be moved to
     const columnNames = columns.map(column => column.title);
     const selectedColumnName = await vscode.window.showQuickPick(columnNames, { placeHolder: 'Select a column to move the card to' });
-    
+
     if (selectedColumnName) {
         const selectedColumn = columns.find(column => column.title === selectedColumnName);
         if (selectedColumn) {
@@ -373,37 +526,37 @@ async function moveCard(card) {
             const { getColumnById } = require('../../out/src/database');
             const currentColumn = getColumnById(card.columnId);
             const completionColumnName = getSettingsService().getKanbanSettings().completionColumn;
-            
+
             debugLog.log(`Destination column: "${selectedColumn.title}" (ID: ${selectedColumn.id})`);
             debugLog.log(`Completion column setting: "${completionColumnName}"`);
-            
+
             // Check if moving to or from completion column (case-insensitive and trimmed)
             const movingToCompletion = selectedColumn.title.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
             const movingFromCompletion = currentColumn.title.toLowerCase().trim() === completionColumnName.toLowerCase().trim();
-            
+
             debugLog.log(`Moving to completion column: ${movingToCompletion}`);
             debugLog.log(`Moving from completion column: ${movingFromCompletion}`);
-            
+
             // STEP 1: Decrement positions of all cards in SOURCE column that are positioned AFTER the current card
             // This effectively removes the card from the source column's position sequence
             debugLog.log('STEP 1: Adjusting positions in source column...');
             const sourceCards = getCardsByColumnId(card.columnId);
             debugLog.log(`Cards in source column before adjustment: ${sourceCards.map(c => `${c.position}:${c.id}`).join(', ')}`);
-            
+
             // Get the current card's position from the database (in case it's changed)
             const currentCard = getCardById(card.cardId);
             const currentPosition = currentCard.position;
             debugLog.log(`Current card position from DB: ${currentPosition}`);
-            
+
             // Decrement positions of cards positioned after the current card in the source column
             reorderCardsOnRemove(card.columnId, currentPosition);
             debugLog.log(`Decremented positions in source column`);
-            
+
             const sourceCardsAfter = getCardsByColumnId(card.columnId);
             debugLog.log(`Cards in source column after adjustment: ${sourceCardsAfter.map(c => `${c.position}:${c.id}`).join(', ')}`);
-            
+
             const updateData = { id: card.cardId, column_id: selectedColumn.id };
-            
+
             // STEP 2: Determine position in destination column
             let position;
             if (movingToCompletion) {
@@ -417,33 +570,33 @@ async function moveCard(card) {
                 const excludeCardId = selectedColumn.id === card.columnId ? card.cardId : undefined;
                 position = await promptForCardPosition(selectedColumn.id, selectedColumn.title, excludeCardId);
                 debugLog.log(`User selected position: ${position}`);
-                
+
                 if (movingFromCompletion) {
                     debugLog.log('Clearing completed_at since moving away from completion column');
                     updateData.completed_at = null;
                 }
             }
-            
+
             // STEP 3: Reorder existing cards in destination column to make space
             debugLog.log(`STEP 3: Reordering cards in destination column at position ${position}...`);
             const destCards = getCardsByColumnId(selectedColumn.id);
             debugLog.log(`Cards in destination column before reorder: ${destCards.map(c => `${c.position}:${c.id}`).join(', ')}`);
-            
+
             reorderCardsOnInsert(selectedColumn.id, position);
-            
+
             const destCardsAfter = getCardsByColumnId(selectedColumn.id);
             debugLog.log(`Cards in destination column after reorder: ${destCardsAfter.map(c => `${c.position}:${c.id}`).join(', ')}`);
-            
+
             updateData.position = position;
-            
+
             debugLog.log(`STEP 4: Updating card with new column (${selectedColumn.id}) and position (${position})`);
             // Update card with new column and position
             updateCard(updateData);
-            
+
             // Save database after all position updates and column changes
             saveDatabase();
             debugLog.log('Database saved after card move');
-            
+
             debugLog.log('==================== MOVE CARD COMPLETE ====================\n');
         }
     } else {

--- a/vscode/server/apiServer.js
+++ b/vscode/server/apiServer.js
@@ -103,7 +103,13 @@ function makeRouter({ token, version, debugLog }) {
 
     const postMatch = method === 'POST' && url.match(/^\/commands\/([^/?]+)$/);
     if (postMatch) {
-      const commandId = decodeURIComponent(postMatch[1]);
+      let commandId;
+      try {
+        commandId = decodeURIComponent(postMatch[1]);
+      } catch {
+        sendJson(res, 400, { ok: false, error: 'invalid command id encoding' });
+        return;
+      }
       const spec = getCommandSpec(commandId);
       if (!spec) {
         sendJson(res, 404, { ok: false, error: `command not exposed: ${commandId}` });

--- a/vscode/server/apiServer.js
+++ b/vscode/server/apiServer.js
@@ -1,0 +1,189 @@
+// Localhost HTTP API exposing a curated set of Chroma extension commands so external
+// tools (Claude Code skill, GitHub Copilot, etc.) can drive the running extension
+// instead of editing chroma.db directly. Driving via commands lets VS Code's in-memory
+// sql.js state stay authoritative — no more silent overwrites of external SQLite edits.
+
+const http = require('http');
+const crypto = require('crypto');
+const vscode = require('vscode');
+const { listCommands, getCommandSpec, validateArgs } = require('./commandRegistry');
+const { writeDiscoveryFile, removeDiscoveryFile } = require('./discovery');
+
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
+const ALLOWED_HOSTS = new Set(['127.0.0.1', 'localhost']);
+
+function generateToken() {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+    'Cache-Control': 'no-store',
+  });
+  res.end(body);
+}
+
+function isAuthorized(req, token) {
+  const header = req.headers['authorization'];
+  if (!header || typeof header !== 'string') return false;
+  const prefix = 'Bearer ';
+  if (!header.startsWith(prefix)) return false;
+  const presented = Buffer.from(header.slice(prefix.length));
+  const expected = Buffer.from(token);
+  if (presented.length !== expected.length) return false;
+  return crypto.timingSafeEqual(presented, expected);
+}
+
+function isLocalHost(req) {
+  const host = (req.headers['host'] || '').split(':')[0];
+  return ALLOWED_HOSTS.has(host);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let received = 0;
+    const chunks = [];
+    req.on('data', (chunk) => {
+      received += chunk.length;
+      if (received > MAX_BODY_BYTES) {
+        reject(Object.assign(new Error('request body too large'), { status: 413 }));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (chunks.length === 0) return resolve({});
+      const raw = Buffer.concat(chunks).toString('utf8');
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        reject(Object.assign(new Error('invalid JSON body'), { status: 400 }));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function makeRouter({ token, version, debugLog }) {
+  return async function handleRequest(req, res) {
+    const url = req.url || '/';
+    const method = req.method || 'GET';
+
+    debugLog?.(`api: ${method} ${url}`);
+
+    if (!isLocalHost(req)) {
+      sendJson(res, 403, { ok: false, error: 'host not allowed' });
+      return;
+    }
+
+    if (method !== 'GET' && method !== 'POST') {
+      res.setHeader('Allow', 'GET, POST');
+      sendJson(res, 405, { ok: false, error: 'method not allowed' });
+      return;
+    }
+
+    if (method === 'GET' && url === '/health') {
+      sendJson(res, 200, { ok: true, version, pid: process.pid });
+      return;
+    }
+
+    if (!isAuthorized(req, token)) {
+      sendJson(res, 401, { ok: false, error: 'unauthorized' });
+      return;
+    }
+
+    if (method === 'GET' && url === '/commands') {
+      sendJson(res, 200, { ok: true, data: listCommands() });
+      return;
+    }
+
+    const postMatch = method === 'POST' && url.match(/^\/commands\/([^/?]+)$/);
+    if (postMatch) {
+      const commandId = decodeURIComponent(postMatch[1]);
+      const spec = getCommandSpec(commandId);
+      if (!spec) {
+        sendJson(res, 404, { ok: false, error: `command not exposed: ${commandId}` });
+        return;
+      }
+
+      let body;
+      try {
+        body = await readBody(req);
+      } catch (e) {
+        sendJson(res, e.status || 400, { ok: false, error: e.message });
+        return;
+      }
+
+      const validationErrors = validateArgs(spec, body);
+      if (validationErrors.length > 0) {
+        sendJson(res, 400, { ok: false, error: 'validation failed', details: validationErrors });
+        return;
+      }
+
+      try {
+        const result = await vscode.commands.executeCommand(commandId, { __api: true, ...body });
+        sendJson(res, 200, { ok: true, data: result ?? null });
+      } catch (e) {
+        debugLog?.(`api: command ${commandId} failed: ${e?.message || String(e)}`);
+        sendJson(res, 500, { ok: false, error: e?.message || String(e) });
+      }
+      return;
+    }
+
+    sendJson(res, 404, { ok: false, error: 'not found' });
+  };
+}
+
+async function startApiServer({ workspaceRoot, version, debugLog }) {
+  if (!workspaceRoot) {
+    debugLog?.('api: no workspace root, skipping HTTP server start');
+    return { stop: () => {} };
+  }
+
+  const token = generateToken();
+  const server = http.createServer(makeRouter({ token, version, debugLog }));
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+
+  let discoveryFilePath;
+  try {
+    discoveryFilePath = writeDiscoveryFile(workspaceRoot, { port, token, version });
+    debugLog?.(`api: listening on 127.0.0.1:${port}, discovery file: ${discoveryFilePath}`);
+  } catch (e) {
+    debugLog?.(`api: failed to write discovery file: ${e?.message || String(e)}`);
+    server.close();
+    throw e;
+  }
+
+  return {
+    port,
+    token,
+    stop() {
+      try {
+        server.close();
+      } catch (e) {
+        debugLog?.(`api: server close error: ${e?.message || String(e)}`);
+      }
+      try {
+        removeDiscoveryFile(workspaceRoot);
+      } catch (e) {
+        debugLog?.(`api: failed to remove discovery file: ${e?.message || String(e)}`);
+      }
+    },
+  };
+}
+
+module.exports = { startApiServer, makeRouter, generateToken };

--- a/vscode/server/apiServer.js
+++ b/vscode/server/apiServer.js
@@ -131,7 +131,9 @@ function makeRouter({ token, version, debugLog }) {
       }
 
       try {
-        const result = await vscode.commands.executeCommand(commandId, { __api: true, ...body });
+        const cmdArg = Object.assign({}, body);
+        cmdArg.__api = true;
+        const result = await vscode.commands.executeCommand(commandId, cmdArg);
         sendJson(res, 200, { ok: true, data: result ?? null });
       } catch (e) {
         debugLog?.(`api: command ${commandId} failed: ${e?.message || String(e)}`);

--- a/vscode/server/commandRegistry.js
+++ b/vscode/server/commandRegistry.js
@@ -1,0 +1,113 @@
+// Source of truth for which VS Code commands the local HTTP API exposes,
+// and what parameters each accepts. Drives both GET /commands (discovery
+// for LLM callers) and POST /commands/:id validation.
+//
+// param.type is one of: 'string' | 'number' | 'boolean' | 'string[]'
+
+const EXPOSED_COMMANDS = [
+  {
+    id: 'chroma.addBoard',
+    description: 'Create a new Kanban board.',
+    params: [
+      { name: 'title', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'chroma.addCard',
+    description: 'Create a new card in a column.',
+    params: [
+      { name: 'columnId', type: 'string', required: true },
+      { name: 'title', type: 'string', required: true },
+      { name: 'content', type: 'string', required: false },
+      { name: 'position', type: 'number', required: false },
+      { name: 'tagIds', type: 'string[]', required: false },
+    ],
+  },
+  {
+    id: 'chroma.editCard',
+    description: 'Edit an existing card.',
+    params: [
+      { name: 'cardId', type: 'string', required: true },
+      { name: 'title', type: 'string', required: false },
+      { name: 'content', type: 'string', required: false },
+      { name: 'tagIds', type: 'string[]', required: false },
+    ],
+  },
+  {
+    id: 'chroma.moveCard',
+    description: 'Move a card to a different column / position.',
+    params: [
+      { name: 'cardId', type: 'string', required: true },
+      { name: 'columnId', type: 'string', required: true },
+      { name: 'position', type: 'number', required: false },
+    ],
+  },
+  {
+    id: 'chroma.deleteCard',
+    description: 'Delete a card.',
+    params: [
+      { name: 'cardId', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'chroma.addTask',
+    description: 'Create a new scheduled task.',
+    params: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'description', type: 'string', required: false },
+      { name: 'dueDate', type: 'string', required: true },
+      { name: 'recurrence', type: 'string', required: false },
+      { name: 'boardId', type: 'string', required: false },
+      { name: 'tagIds', type: 'string[]', required: false },
+    ],
+  },
+  {
+    id: 'chroma.completeTask',
+    description: 'Mark a scheduled task as completed.',
+    params: [
+      { name: 'taskId', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'chroma.deleteTask',
+    description: 'Delete a scheduled task.',
+    params: [
+      { name: 'taskId', type: 'string', required: true },
+    ],
+  },
+];
+
+const COMMAND_INDEX = new Map(EXPOSED_COMMANDS.map((c) => [c.id, c]));
+
+function listCommands() {
+  return EXPOSED_COMMANDS;
+}
+
+function getCommandSpec(id) {
+  return COMMAND_INDEX.get(id);
+}
+
+function validateArgs(spec, body) {
+  const args = body && typeof body === 'object' ? body : {};
+  const errors = [];
+  for (const p of spec.params) {
+    const present = Object.prototype.hasOwnProperty.call(args, p.name) && args[p.name] !== null && args[p.name] !== undefined;
+    if (p.required && !present) {
+      errors.push(`missing required param: ${p.name}`);
+      continue;
+    }
+    if (!present) continue;
+    const v = args[p.name];
+    if (p.type === 'string' && typeof v !== 'string') errors.push(`${p.name} must be a string`);
+    else if (p.type === 'number' && typeof v !== 'number') errors.push(`${p.name} must be a number`);
+    else if (p.type === 'boolean' && typeof v !== 'boolean') errors.push(`${p.name} must be a boolean`);
+    else if (p.type === 'string[]') {
+      if (!Array.isArray(v) || v.some((x) => typeof x !== 'string')) {
+        errors.push(`${p.name} must be an array of strings`);
+      }
+    }
+  }
+  return errors;
+}
+
+module.exports = { listCommands, getCommandSpec, validateArgs };

--- a/vscode/server/commandRegistry.js
+++ b/vscode/server/commandRegistry.js
@@ -90,6 +90,12 @@ function getCommandSpec(id) {
 function validateArgs(spec, body) {
   const args = body && typeof body === 'object' ? body : {};
   const errors = [];
+  const allowedKeys = new Set(spec.params.map((p) => p.name));
+  for (const key of Object.keys(args)) {
+    if (!allowedKeys.has(key)) {
+      errors.push(`unknown param: ${key}`);
+    }
+  }
   for (const p of spec.params) {
     const present = Object.prototype.hasOwnProperty.call(args, p.name) && args[p.name] !== null && args[p.name] !== undefined;
     if (p.required && !present) {

--- a/vscode/server/discovery.js
+++ b/vscode/server/discovery.js
@@ -38,7 +38,15 @@ function removeDiscoveryFile(workspaceRoot) {
   try {
     fs.unlinkSync(filePath);
   } catch (e) {
-    if (e.code !== 'ENOENT') throw e;
+    if (e.code === 'ENOENT') return;
+    // Unlink failed (e.g. permission error on Windows). Write a sentinel so
+    // external callers can tell the server is gone even if the file lingers.
+    try {
+      fs.writeFileSync(filePath, JSON.stringify({ active: false }), { encoding: 'utf8' });
+    } catch {
+      // Best-effort; nothing more we can do at shutdown time.
+    }
+    throw e;
   }
 }
 

--- a/vscode/server/discovery.js
+++ b/vscode/server/discovery.js
@@ -13,11 +13,7 @@ function discoveryPath(workspaceRoot) {
 
 function writeDiscoveryFile(workspaceRoot, info) {
   const dir = path.join(workspaceRoot, '.chroma');
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-  } catch (e) {
-    if (e.code !== 'EEXIST') throw e;
-  }
+  fs.mkdirSync(dir, { recursive: true });
   const filePath = discoveryPath(workspaceRoot);
   const payload = JSON.stringify({
     port: info.port,

--- a/vscode/server/discovery.js
+++ b/vscode/server/discovery.js
@@ -1,0 +1,49 @@
+// Manages the .chroma/api.json discovery file. External callers (Claude Code skill,
+// other LLM tools) read this to find the running extension's HTTP port + auth token.
+// File is rewritten on each activation (token rotates per session) and deleted on shutdown.
+
+const fs = require('fs');
+const path = require('path');
+
+const FILENAME = 'api.json';
+
+function discoveryPath(workspaceRoot) {
+  return path.join(workspaceRoot, '.chroma', FILENAME);
+}
+
+function writeDiscoveryFile(workspaceRoot, info) {
+  const dir = path.join(workspaceRoot, '.chroma');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (e) {
+    if (e.code !== 'EEXIST') throw e;
+  }
+  const filePath = discoveryPath(workspaceRoot);
+  const payload = JSON.stringify({
+    port: info.port,
+    token: info.token,
+    pid: process.pid,
+    version: info.version,
+    startedAt: new Date().toISOString(),
+  }, null, 2);
+
+  fs.writeFileSync(filePath, payload, { encoding: 'utf8' });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort; Windows ignores POSIX modes
+  }
+  return filePath;
+}
+
+function removeDiscoveryFile(workspaceRoot) {
+  if (!workspaceRoot) return;
+  const filePath = discoveryPath(workspaceRoot);
+  try {
+    fs.unlinkSync(filePath);
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+}
+
+module.exports = { writeDiscoveryFile, removeDiscoveryFile, discoveryPath };


### PR DESCRIPTION
# feat: add localhost HTTP API for external tool integration

## Summary

Adds a localhost HTTP server that starts alongside the extension, allowing external tools (Claude Code skills, GitHub Copilot, scripts) to drive the running extension over HTTP instead of editing `chroma.db` directly. Driving via VS Code commands keeps the extension's in-memory sql.js state authoritative and avoids silent data loss from concurrent SQLite writes.

### What's new

**`vscode/server/apiServer.js`** — Localhost HTTP server bound to `127.0.0.1` on a random port. Handles auth via a per-session `Bearer` token (timing-safe comparison), enforces host allowlisting, validates request bodies against the command registry, and dispatches to `vscode.commands.executeCommand`.

**`vscode/server/commandRegistry.js`** — Declares the 8 exposed commands and their param schemas, serving as the source of truth for both runtime validation and the `GET /commands` discovery endpoint.

**`vscode/server/discovery.js`** — Writes `.chroma/api.json` to the workspace root on activation (port, token, pid, version) and removes it on shutdown. External callers read this file to find the server without any hardcoded port.

### Endpoints

| Method | Path | Auth | Description |
|---|---|---|---|
| `GET` | `/health` | None | Liveness check |
| `GET` | `/commands` | Bearer token | List all exposed commands and their schemas |
| `POST` | `/commands/:id` | Bearer token | Execute a command with JSON body args |

### Exposed commands

`chroma.addBoard`, `chroma.addCard`, `chroma.editCard`, `chroma.moveCard`, `chroma.deleteCard`, `chroma.addTask`, `chroma.completeTask`, `chroma.deleteTask`

### Supporting changes

- **`vscode/extension.js`** — Wires `startApiServer` into `activate()`; refactors 8 command handlers from fire-and-forget `.then()` to `async/await` so they return results through the API. Adds an early-return guard when no workspace folder is open (previously caused a `getDb()` crash on first tree view render).
- **`src/Task.ts`, `vscode/kanban/Card.js`, `vscode/kanban/Board.js`** — Command implementations now accept an optional `arg` object so the API can pass params programmatically alongside the existing VS Code UI flow.
- **`test/apiServer.test.ts`** — Unit tests covering auth, routing, body validation, command dispatch, and error handling.
- **`test/database-persistence.test.ts`** — Replace deprecated `fs.rmdirSync({ recursive })` with `fs.rmSync({ recursive, force })`.
- **`README.md`** — Documents the API, discovery mechanism, and all endpoints.

## Test plan

- [ ] `npm test` passes (374 tests, 0 failures)
- [ ] Launch Extension Development Host (F5) with a workspace folder open
- [ ] Confirm `.chroma/api.json` is written to the workspace root
- [ ] `GET /health` returns `{"ok":true}`
- [ ] `GET /commands` with valid token returns the 8 exposed commands
- [ ] `POST /commands/chroma.addCard` creates a card visible in the Kanban panel
- [ ] Request with wrong token returns HTTP 401
- [ ] Closing the Extension Development Host removes `.chroma/api.json`
